### PR TITLE
Add placeholder documentation for one-click installation

### DIFF
--- a/docs/contents/development.rst
+++ b/docs/contents/development.rst
@@ -7,6 +7,59 @@ Developer Guide
    Statistical and machine learning models will be made available once fully
    validated.
 
+************
+Installation
+************
+
+We recommend to install
+an up-to-date version of **[NiBAχ]** using `pip`.
+The only requirement is Python 3.8 or newer.
+All dependencies will be installed automatically.
+The software is compatible with Windows 10/11, macOS, and Linux.
+
+To start the installation, start a terminal and check the installed version
+of Python.
+The output should show a version `3.8` or newer.
+If the command is not recognized, Python is not installed or the `python` command
+is not found by the system.
+If Python is installed--for instance in Windows, it is possible to call the command
+with the full path.
+
+.. tabs::
+
+   .. code-tab:: text Windows 10/11
+
+         python --version
+         # or, if `python` not in PATH
+         C:\Users\USERNAME\AppData\Local\Programs\Python\Python39\python.exe --version
+
+   .. code-tab:: shell macOS
+
+         /usr/bin/python --version
+
+   .. code-tab:: shell Linux
+
+         /usr/bin/python --version
+
+
+It is recommended to install **[NiBAx]** in a virtual Python environment.
+Shown below is an installation into the folder `.env` in the current working
+directory.
+
+.. code-block:: shell
+
+    python -m venv .env
+    source .env/bin/activate
+    python -m pip install https://github.com/CBICA/NiBAx
+
+
+Once installed, the GUI is accesible as command `NiBAx`.
+
+.. code-block:: shell
+
+    # Typing NiBAx in an activated virtual environment
+    # will launch the graphical user interface.
+    NiBAx
 
 ***************************
 Build documentation locally

--- a/docs/contents/userguide.rst
+++ b/docs/contents/userguide.rst
@@ -12,6 +12,15 @@ User Guide
 Installation
 ************
 
+`Windows <https://github.com/CBICA/NiBAx/releases>`_
+
+`macOS <https://github.com/CBICA/NiBAx/releases>`_
+
+`Linux <https://github.com/CBICA/NiBAx/releases>`_
+
+Alternate releases of **[NiBAχ]** can be found `here <https://github.com/CBICA/NiBAx/tags>`_. 
+
+
 Until one-click installation packages are available, we recommend to install
 an up-to-date version of **[NiBAχ]** using `pip`.
 The only requirement is Python 3.8 or newer.

--- a/docs/contents/userguide.rst
+++ b/docs/contents/userguide.rst
@@ -12,11 +12,7 @@ User Guide
 Installation
 ************
 
-`Windows <https://github.com/CBICA/NiBAx/releases>`_
-
-`macOS <https://github.com/CBICA/NiBAx/releases>`_
-
-`Linux <https://github.com/CBICA/NiBAx/releases>`_
+The easiest method to install the toolbox is via the binary installers for Windows, macOS, and Linux.
 
 Alternate releases of **[NiBAχ]** can be found `here <https://github.com/CBICA/NiBAx/tags>`_. 
 


### PR DESCRIPTION
PR creates placeholder links to the release and tag pages on GitHub to lead users to one-click installation of the NiBAx app. Once release is created, these will be replaced. Copy of pip installation instructions added to developer guide. 