### PR TITLE
Add arguments to choose SPARE-* column names

### DIFF
--- a/NiBAx/core/model/datamodel.py
+++ b/NiBAx/core/model/datamodel.py
@@ -236,7 +236,8 @@ class DataModel(QObject):
 
         return stats
 
-    def AddSparesToDataModel(self,spares):
-        self.data.loc[:,'SPARE_AD'] = spares['SPARE_AD']
-        self.data.loc[:,'SPARE_BA'] = spares['SPARE_BA']
+    def AddSparesToDataModel(self,spares,SPARE_AD='SPARE_AD',
+                             SPARE_BA='SPARE_BA'):
+        self.data.loc[:,SPARE_AD] = spares['SPARE_AD']
+        self.data.loc[:,SPARE_BA] = spares['SPARE_BA']
         self.data_changed.emit()


### PR DESCRIPTION
This adds the ability to set a custom column name for `SPARE_AD` and `SPARE_BA`, respectively.