### PR TITLE
Fix crash because of non-existing WMLS column names

### DIFF
--- a/NiBAx/__main__.py
+++ b/NiBAx/__main__.py
@@ -31,7 +31,15 @@ def main():
     output_file = args.output_file_name
     noGUI = args.nogui
 
-    if(noGUI == None):
+
+    if(noGUI):
+        app = QtCore.QCoreApplication(sys.argv)
+        if(compute_spares):
+            if((data_file == None) or (SPARE_model_file == None) or (output_file == None)):
+                print("Please provide '--data_file', '--SPARE_model_file' and '--output_file_name' to compute spares.")
+                exit()
+            NiBAxCmdApp().ComputeSpares(data_file,SPARE_model_file,output_file)
+    else:
         app = QtWidgets.QApplication(sys.argv)
         mw = MainWindow(dataFile=data_file,
                         harmonizationModelFile=harmonization_model_file,
@@ -39,9 +47,6 @@ def main():
         mw.show()
 
         sys.exit(app.exec_())
-    else:
-        app = QtCore.QCoreApplication(sys.argv)
-        NiBAxCmdApp().ComputeSpares(data_file,SPARE_model_file,output_file)
 
 if __name__ == '__main__':
     main()

--- a/NiBAx/plugins/agetrends/agetrends.py
+++ b/NiBAx/plugins/agetrends/agetrends.py
@@ -52,14 +52,11 @@ class AgeTrends(QtWidgets.QWidget,BasePlugin):
             + ['SPARE_AD','SPARE_BA','Non-existing-ROI','DLICV'])
 
         # !!! remove ROI with no dictionary entry
-        if 'WMLS_Volume_43' in roiList:
-            roiList.remove('WMLS_Volume_43')
-
-        if 'WMLS_Volume_42' in roiList:
-            roiList.remove('WMLS_Volume_42')
-
-        if 'WMLS_Volume_69' in roiList:
-            roiList.remove('WMLS_Volume_69')
+        for invalid_ROI in ['WMLS_Volume_43', 'WMLS_Volume_42', 'WMLS_Volume_69',
+                            'WMLS_Volume_1', 'WMLS_Volume_621', 'WMLS_Volume_622',
+                            'WMLS_Volume_700' ]:
+            if invalid_ROI in roiList:
+                roiList.remove(invalid_ROI)
 
 
         _, MUSEDictIDtoNAME = self.datamodel.GetMUSEDictionaries()


### PR DESCRIPTION
@melhemr This should fix the issue with crashing `AgeTrends` plugin when the data set contains one of the WMLS ROIs that is not in the dictionary. Please test it out with the current version of the iSTAGING data. Thanks.