### PR TITLE
Set default output file to None

### DIFF
--- a/NiBAx/NiBAxCmdApp.py
+++ b/NiBAx/NiBAxCmdApp.py
@@ -38,7 +38,7 @@ class NiBAxCmdApp:
         return self
 
 
-    def Harmonize(self, harmonizationmodelfile,outputfile):
+    def Harmonize(self, harmonizationmodelfile,outputfile=None):
 
         print("Reading harmonization model")
         harmonizationmodel = self.dio.ReadPickleFile(harmonizationmodelfile)
@@ -57,7 +57,7 @@ class NiBAxCmdApp:
         print("Done")
         return self
 
-    def ComputeSpares(self, sparesmodelfile, outputfile):
+    def ComputeSpares(self, sparesmodelfile, outputfile=None):
 
         print("reading spare model")
         sparemodel = {'BrainAge': None, 'AD': None}


### PR DESCRIPTION
This will add a default output of `None` such that it is not necessary to specifically set it to `None` when calling `Harmonize()` or `ComputeSpares().